### PR TITLE
dont lowercase fields names

### DIFF
--- a/base.py
+++ b/base.py
@@ -54,7 +54,7 @@ class ClickHouseIdentifierPreparer(PGIdentifierPreparer):
         return self._escape_identifier(value)
     def quote(self, ident, force=None):
         if self._requires_quotes(ident):
-            return '"{}"'.format(ident).lower()
+            return '"{}"'.format(ident)
         return ident
 
 class ClickHouseCompiler(PGCompiler):


### PR DESCRIPTION
Hi!
I can not create issue, so I want to report bug here.
This code breaks camelCase-named field names and connector won't work with it.